### PR TITLE
Don't use escapeshellcmd (fix bad results from pa11y)

### DIFF
--- a/src/Metric.php
+++ b/src/Metric.php
@@ -183,7 +183,7 @@ class Metric extends MetricInterface
         
         $command .= ' ' . escapeshellarg($uri);
         
-        $json = exec(escapeshellcmd($command));
+        $json = exec($command);
         
         if (!$data = json_decode($json, true)) {
             return false;


### PR DESCRIPTION
We are already escaping the arguments using escapeshellarg.  The rest of the command is hand crafted and not exposed to user input.

Using escapeshellcmd was escaping `?` in URIs, resulting in bad results from pa11y.
