### PR TITLE
prevent pa11y from stalling the queue

### DIFF
--- a/service.php
+++ b/service.php
@@ -30,8 +30,12 @@ function getResults($uri, $plugin_options)
 
 header('Content-Type: application/json');
 
-if (!isset($_GET['url'])) {
+if (!isset($_GET['page'])) {
     throw new \SiteMaster\Core\InvalidArgumentException('A URL is required', 400);
 }
 
-echo getResults($_GET['url'], $options);
+if (!$page = \SiteMaster\Core\Auditor\Site\Page::getByID($_GET['page'])) {
+    throw new \SiteMaster\Core\InvalidArgumentException('Page Not Found', 400);
+}
+
+echo getResults($page->uri, $options);

--- a/service.php
+++ b/service.php
@@ -1,0 +1,37 @@
+<?php
+require_once(__DIR__ . '/../../init.php');
+$metric_pa11y = \SiteMaster\Core\Plugin\PluginManager::getManager()->getPluginInfo('metric_pa11y');
+$options = $metric_pa11y->getOptions();
+
+function getResults($uri, $plugin_options)
+{
+    $command = $plugin_options['pa11y_path']
+        . ' -r json'
+        . ' -s ' . escapeshellarg($plugin_options["standard"])
+        . ' -c ' . escapeshellarg($plugin_options['html_codesniffer_url'] . 'HTMLCS.js');
+
+    $config_file = dirname(__DIR__) . '/config/pa11y.json';
+    if (file_exists($config_file)) {
+        $command .= ' --config ' . $config_file;
+    }
+
+    $command .= ' ' . escapeshellarg($uri);
+
+    /**
+     * Execute with a 25 second timeout (just under the default of 30).
+     * one or more of pa11y, phantomjs, or node have an issue where child process are not being killed and turn into zombies.
+     * $this->exec aims to curb that problem by manually setting a timeout.
+     */
+    $command_helper = new \SiteMaster\Plugins\Metric_pa11y\CommandHelper();
+    list($exitStatus, $output, $stderr) = $command_helper->exec($command, 25);
+    
+    return $output;
+}
+
+header('Content-Type: application/json');
+
+if (!isset($_GET['url'])) {
+    throw new \SiteMaster\Core\InvalidArgumentException('A URL is required', 400);
+}
+
+echo getResults($_GET['url'], $options);

--- a/service.php
+++ b/service.php
@@ -10,7 +10,7 @@ function getResults($uri, $plugin_options)
         . ' -s ' . escapeshellarg($plugin_options["standard"])
         . ' -c ' . escapeshellarg($plugin_options['html_codesniffer_url'] . 'HTMLCS.js');
 
-    $config_file = dirname(__DIR__) . '/config/pa11y.json';
+    $config_file = __DIR__ . '/config/pa11y.json';
     if (file_exists($config_file)) {
         $command .= ' --config ' . $config_file;
     }

--- a/src/Metric.php
+++ b/src/Metric.php
@@ -90,7 +90,7 @@ class Metric extends MetricInterface
      */
     public function scan($uri, \DOMXPath $xpath, $depth, Page $page, Metrics $context)
     {
-        $results = $this->getResults($uri);
+        $results = $this->getResults($page->id);
         $marks = array();
         
         if (!isset($results['results'])) {
@@ -177,12 +177,12 @@ class Metric extends MetricInterface
     /**
      * Get the results for a given uri
      * 
-     * @param $uri
+     * @param $id - the id of the page
      * @return bool|mixed
      */
-    public function getResults($uri)
+    public function getResults($id)
     {
-        $request_url = Config::get('URL') . 'plugins/metric_pa11y/service.php?url=' . urlencode($uri);
+        $request_url = Config::get('URL') . 'plugins/metric_pa11y/service.php?page=' . $id;
 
         $stream_context = stream_context_create(array(
             'http'=> array (

--- a/src/Metric.php
+++ b/src/Metric.php
@@ -3,6 +3,7 @@ namespace SiteMaster\Plugins\Metric_pa11y;
 
 use SiteMaster\Core\Auditor\Logger\Metrics;
 use SiteMaster\Core\Auditor\MetricInterface;
+use SiteMaster\Core\Config;
 use SiteMaster\Core\Registry\Site;
 use SiteMaster\Core\Auditor\Scan;
 use SiteMaster\Core\Auditor\Site\Page;
@@ -28,8 +29,6 @@ class Metric extends MetricInterface
     public function __construct($plugin_name, array $options = array())
     {
         $options = array_replace_recursive(array(
-            'pa11y_path' => 'pa11y',
-            'standard' => 'WCAG2AA', //The standard to test against (Section508, WCAG2A, WCAG2AA (default), WCAG2AAA)
             'help_text_general' => 'To locate this error on your page install the bookmarklet found in the metric description and run it on your page.',
             'grading_method' => self::GRADE_METHOD_DEFAULT,
             'point_deductions' => array(
@@ -91,7 +90,7 @@ class Metric extends MetricInterface
      */
     public function scan($uri, \DOMXPath $xpath, $depth, Page $page, Metrics $context)
     {
-        $results = $this->getREsults($uri);
+        $results = $this->getResults($uri);
         $marks = array();
         
         if (!isset($results['results'])) {
@@ -183,27 +182,19 @@ class Metric extends MetricInterface
      */
     public function getResults($uri)
     {
-        $plugin_options = $this->getPlugin()->getOptions();
-        
-        $command = $this->options['pa11y_path']
-            . ' -r json'
-            . ' -s ' . escapeshellarg($this->options["standard"])
-            . ' -c ' . escapeshellarg($plugin_options['html_codesniffer_url'] . 'HTMLCS.js');
-        
-        $config_file = dirname(__DIR__) . '/config/pa11y.json';
-        if (file_exists($config_file)) {
-            $command .= ' --config ' . $config_file;
-        }
-        
-        $command .= ' ' . escapeshellarg($uri);
+        $request_url = Config::get('URL') . 'plugins/metric_pa11y/service.php?url=' . urlencode($uri);
 
-        /**
-         * Execute with a 25 second timeout (just under the default of 30).
-         * one or more of pa11y, phantomjs, or node have an issue where child process are not being killed and turn into zombies.
-         * $this->exec aims to curb that problem by manually setting a timeout.
-         */
-        $command_helper = new CommandHelper();
-        list($exitStatus, $output, $stderr) = $command_helper->exec($command, 25);
+        $stream_context = stream_context_create(array(
+            'http'=> array (
+                'timeout' => 30 // 30 sec
+            )
+        ));
+
+        $output = file_get_contents($request_url, false, $stream_context);
+        
+        if (!$output) {
+            return false;
+        }
         
         //Output MAY contain many lines, but the json response is always on one line.
         $output = explode(PHP_EOL, $output);

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -8,7 +8,9 @@ use SiteMaster\Core\Events\RegisterTheme;
 class Plugin extends PluginInterface
 {
     protected $options = array(
-        'html_codesniffer_url' => '//squizlabs.github.io/HTML_CodeSniffer/build/'
+        'html_codesniffer_url' => '//squizlabs.github.io/HTML_CodeSniffer/build/',
+        'pa11y_path'           => 'pa11y',
+        'standard'             => 'WCAG2AA', //The standard to test against (Section508, WCAG2A, WCAG2AA (default), WCAG2AAA)
     );
     
     /**

--- a/www/templates/html/Metric.tpl.php
+++ b/www/templates/html/Metric.tpl.php
@@ -2,7 +2,8 @@
     Pa11y can't catch all accessibility errors. It'll catch many of them, but you should do manual checking as well.
 </p>
 <p>
-    Only distinct <?php echo $context->options['standard'] ?> errors are being reported.  Warnings and notices are being ignored and require manual checking.  To locate and fix errors on your page, drag this link to your browser bookmarks bar:
+    <?php $plugin_options = $context->getPlugin()->getOptions(); ?>
+    Only distinct <?php echo $plugin_options['standard'] ?> errors are being reported.  Warnings and notices are being ignored and require manual checking.  To locate and fix errors on your page, drag this link to your browser bookmarks bar:
     <a href="javascript:(function(){var e='<?php echo $base_url ?>plugins/metric_pa11y/widget.php';var t='<?php echo $base_url ?>www/js/vendor/jquery.js';var n=function(e,t){var n=document.createElement('script');n.onload=function(){n.onload=null;n.onreadystatechange=null;t.call(this)};n.onreadystatechange=function(){if(/^(complete|loaded)$/.test(this.readyState)===true){n.onreadystatechange=null;n.onload()}};n.src=e;if(document.head){document.head.appendChild(n)}else{document.getElementsByTagName('head')[0].appendChild(n)}};var r=function(){jQuery.getScript(e)};if(typeof jQuery==='undefined'){n(t,function(){r()})}else{r()}})();" onclick="alert('Drag this to your browser Bookmarks Bar to install.  Once installed, you can run the WCAG Bookmarklet over any page.'); return false;">SiteMaster Pa11y</a>, then click the 'HTML CodeSniffer' bookmark to run accessibility tests on any page.  Note that pages are checked at a mobile width.
 </p>
 


### PR DESCRIPTION
Sometimes, pa11y gets hung up and stalls the queue for days until it is manually restarted.  I'm not sure why this is happening, as I can't reproduce the problem at all.  However, abstracting the pa11y logic out of the queue and into a separate request should fix this problem, because the http request will always time out after 30 seconds.
